### PR TITLE
Update metadata to allow extension to work in 3.8 and 3.10.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Remove the Application Menu on the top bar", 
   "name": "Remove App Menu", 
-  "shell-version": ["3.6"], 
+  "shell-version": ["3.6","3.8","3.10"], 
   "uuid": "RemoveAppMenu@rastersoft.com"
 }


### PR DESCRIPTION
This extension works as-is for Gnome shell 3.10. Let's update the metadata.json to allow 3.8 and 3.10 users to install this.
